### PR TITLE
Handle '-inf' values in log2fc

### DIFF
--- a/TRAP.py
+++ b/TRAP.py
@@ -212,7 +212,7 @@ def main() :
                                 tp = l.split()
 				if not is_number(tp[9]) :
 					continue
-				if tp[9]=='inf' :
+				if ( tp[9]=='inf' or tp[9] == '-inf') :
 					temp[tp[2]]=0
 				else: 
 	                                temp[tp[2]]=float(tp[9])


### PR DESCRIPTION
A minor change to test pull request processing. For the code itself, I encountered the output that contains '-inf' values for log2fc. Hence the fix.
